### PR TITLE
Fix v4 download links

### DIFF
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -25,7 +25,9 @@ class Home extends BaseController
 		// build the localized "biglinks"
 		$this->data['biglinks'] = [
 			['icon'	 => 'download',
-				'link'	 => 'https://github.com/codeigniter4/CodeIgniter4/archive/' . $this->data['v4name'] ?? '' . '.zip',
+				'link'	 => empty($this->data['v4name'])
+					? 'https://github.com/codeigniter4/framework/releases/'
+					: 'https://github.com/codeigniter4/framework/archive/' . $this->data['v4name'] . '.zip',
 				'label'	 => lang('Home.block1Title'),
 				'text'	 => lang('Home.block1Desc') . $this->data['v4name'] ?? ''],
 			['icon'	 => 'book',

--- a/app/Views/download.php
+++ b/app/Views/download.php
@@ -24,7 +24,7 @@
 
                     <ul class="nav nav-pills justify-content-center">
                         <li class="nav-item" style="margin:0.5em;">
-                            <a href="http://github.com/codeigniter4/CodeIgniter4/archive/<?= esc($v4name, 'attr') ?>.zip" class="nav-link btn-success" title="Download the latest version">
+                            <a href="http://github.com/codeigniter4/framework/archive/<?= esc($v4name, 'attr') ?>.zip" class="nav-link btn-success" title="Download the latest version">
                                 <i class="glyphicon glyphicon-save"></i> Download
                             </a>
                         </li>


### PR DESCRIPTION
The current v4 download links incorrectly reference `codeigniter4/codeigniter4` instead of pointing to `codeigniter4/framework`. The GitHub API helper is harvesting the correct tags, so this PR just fixes the actual links. This also fixes an issue with concatenation resolution that was dropping the ".zip" from the homepage link.
