### PR TITLE
Version Descriptions

### DIFF
--- a/app/Views/download.php
+++ b/app/Views/download.php
@@ -5,7 +5,7 @@
 
         <div class="col-md-12 col-sm-12 text-center title">
             <span class="glyphicon glyphicon-download big-glyph"></span>
-            CodeIgniter comes in three flavors: CodeIgniter 3 (current), CodeIgniter 4 (future) and CodeIgniter 2 (legacy)
+            CodeIgniter has two supported versions: CodeIgniter 4 (current) and CodeIgniter 3 (legacy)
         </div>
 
         <!-- CodeIgniter 4 -->
@@ -14,11 +14,11 @@
                 <div class="well download">
                     <h3 class="text-center">CodeIgniter 4</h3>
 
-                    <p>CodeIgniter 4 is the upcoming version of the framework, intended for use with PHP 7.2.</p>
+                    <p>CodeIgniter 4 is the current version of the framework, intended for use with PHP 7.3+ (including 8.0).</p>
 
-                    <p>Development is underway, and the current version is <?= esc($v4name) ?>.</p>
+                    <p>Development is ongoing, and the current version is <?= esc($v4name) ?>.</p>
 
-                    <p>You *could* download the V4 framework using the button below, but we encourage you
+                    <p>You *could* download this version of the framework using the button below, but we encourage you
                         to check the <a href="https://codeigniter4.github.io/userguide/installation/index.html">Installation section</a>
                         of the User Guide, to choose from several different ways you can install the framework :)</p>
 
@@ -54,7 +54,7 @@
                 <div class="well download">
                     <h3 class="text-center">CodeIgniter 3</h3>
 
-                    <p>CodeIgniter <?= esc($v3name) ?> is the current version of the framework, intended for use with PHP 5.6+.</p>
+                    <p>CodeIgniter <?= esc($v3name) ?> is the legacy version of the framework, intended for use with PHP 5.6+.</p>
 
                     <p>There have been a number of refinements since version 2, notably with the database,
                         session handling and encryption. Development of this version is ongoing.</p>

--- a/app/Views/download.php
+++ b/app/Views/download.php
@@ -54,10 +54,9 @@
                 <div class="well download">
                     <h3 class="text-center">CodeIgniter 3</h3>
 
-                    <p>CodeIgniter <?= esc($v3name) ?> is the legacy version of the framework, intended for use with PHP 5.6+.</p>
+                    <p>CodeIgniter 3 is the legacy version of the framework, intended for use with PHP 5.6+.</p>
 
-                    <p>There have been a number of refinements since version 2, notably with the database,
-                        session handling and encryption. Development of this version is ongoing.</p>
+                    <p>This version is in maintenance, receiving mostly just security updates, and the current version is <?= esc($v3name) ?>.</p>
 
                     <ul class="nav nav-pills justify-content-center">
                         <li class="nav-item" style="margin:0.5em;">


### PR DESCRIPTION
We really need to get rid of the "upcoming" text for version 4. This is a pass at rewording the download page to be more clear. I realize there might be some controversy around terming version 3 "legacy" but my compromise is to leave in the note that its development is "ongoing".